### PR TITLE
Piz1 cant create an order bug

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,10 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+@size.route('/', methods=GET)
+def get_size():
+    size, error = SizeController.get_all()
+    response = size if not error else {'error': error}
+    status_code = 200 if size else 404 if not error else 400
+    return jsonify(response), status_code


### PR DESCRIPTION
Ticket link: [PIZ1 - I can't create an order (Bug)](https://trello.com/c/s7KFDYue/1-piz1-i-cant-create-an-order-bug)

**Description:** To solve the bug where the size items created by the user were not shown in homepage, a service was created that retrieves a list of the all sizes. Also, from now it is possible to created a full order. This new order appears on the Orders page and in the db.

**Test Scenarios**: This service is now accesible by entering [http://127.0.0.1:5000/size/](http://127.0.0.1:5000/size/) when the server is running.